### PR TITLE
Fix Linux build configuration and conditionally enable package makers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,8 @@ jobs:
           NODE_OPTIONS: "--max-old-space-size=4096"
           # Explicitly disable RPM building on Ubuntu
           BUILD_RPM: "false"
+          # Disable DEB building in CI to avoid compatibility issues
+          BUILD_DEB: "false"
           # Disable code signing for CI builds
           CSC_IDENTITY_AUTO_DISCOVERY: "false"
           # Ensure we're building for the correct platform
@@ -76,7 +78,6 @@ jobs:
         with:
           name: linux-builds
           path: |
-            out/make/deb/x64/*.deb
             out/make/zip/linux/x64/*.zip
           retention-days: 30
 
@@ -208,7 +209,7 @@ jobs:
       - name: List all artifacts
         run: |
           echo "=== All downloaded artifacts ==="
-          find artifacts/ -type f -name "*.exe" -o -name "*.deb" -o -name "*.rpm" -o -name "*.zip" -o -name "*.dmg" || echo "No artifacts found"
+          find artifacts/ -type f -name "*.exe" -o -name "*.zip" -o -name "*.dmg" || echo "No artifacts found"
           echo "=== Artifact details ==="
           ls -la artifacts/linux/ || echo "No Linux artifacts"
           ls -la artifacts/macos/ || echo "No macOS artifacts"
@@ -222,8 +223,6 @@ jobs:
           draft: false
           prerelease: false
           files: |
-            artifacts/linux/*.deb
-            artifacts/linux/*.rpm
             artifacts/linux/*.zip
             artifacts/macos/*.zip
             artifacts/windows/*.exe
@@ -247,9 +246,8 @@ jobs:
             - Download the `.zip` file and extract to Applications
 
             **Linux:**
-            - Debian/Ubuntu: Use the `.deb` package
-            - Red Hat/Fedora: Use the `.rpm` package
-            - Other: Use the `.zip` file
+            - Download the `.zip` file and extract to your preferred location
+            - Run the executable from the extracted folder
 
             ### 🔧 Installation
             1. Download the appropriate file for your platform

--- a/BUILD_FIX.md
+++ b/BUILD_FIX.md
@@ -1,0 +1,67 @@
+# Build Fix Documentation
+
+## Issue
+The Linux build was failing with the error:
+```
+Cannot make for linux and target deb: the maker declared that it cannot run on linux.
+```
+
+This was caused by the `MakerDeb` in the Electron Forge configuration not being compatible with the CI environment.
+
+## Solution
+The forge configuration has been updated to conditionally enable/disable makers based on environment variables:
+
+### Environment Variables
+
+- `BUILD_DEB`: Controls whether to build `.deb` packages
+  - Set to `"false"` to disable (recommended for CI)
+  - Default: enabled (when not set or set to any other value)
+
+- `BUILD_RPM`: Controls whether to build `.rpm` packages
+  - Set to `"true"` to enable
+  - Default: disabled
+
+### CI Configuration
+The GitHub Actions workflow has been updated to:
+1. Set `BUILD_DEB=false` for Linux builds
+2. Only generate ZIP files for Linux (no `.deb` or `.rpm`)
+3. Update artifact paths and release notes accordingly
+
+### Local Development
+For local development, you can:
+
+1. **Test the configuration:**
+   ```bash
+   npm run test:forge-config
+   ```
+
+2. **Build with specific makers:**
+   ```bash
+   # Build with deb packages (default)
+   npm run make:linux
+   
+   # Build without deb packages (CI mode)
+   BUILD_DEB=false npm run make:linux
+   
+   # Build with rpm packages
+   BUILD_RPM=true npm run make:linux
+   ```
+
+### Build Outputs
+- **CI Builds**: Only ZIP files for Linux
+- **Local Builds**: ZIP files + DEB packages (unless disabled)
+- **RPM Builds**: Only when `BUILD_RPM=true` is set
+
+## Files Modified
+1. `forge.config.ts` - Added conditional logic for makers
+2. `.github/workflows/release.yml` - Updated CI configuration
+3. `scripts/test-forge-config.js` - Added test script
+4. `package.json` - Added test script command
+
+## Testing
+Run the test script to verify the configuration works:
+```bash
+npm run test:forge-config
+```
+
+This will test the configuration with different environment variable combinations.

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -8,6 +8,12 @@ import { FusesPlugin } from "@electron-forge/plugin-fuses";
 import { FuseV1Options, FuseVersion } from "@electron/fuses";
 import { AutoUnpackNativesPlugin } from "@electron-forge/plugin-auto-unpack-natives";
 
+// Environment variables for build configuration:
+// - BUILD_DEB: Set to "false" to disable deb package creation (useful in CI)
+// - BUILD_RPM: Set to "true" to enable rpm package creation
+// - SM_CODE_SIGNING_CERT_SHA1_HASH: Windows code signing certificate hash
+// - APPLE_TEAM_ID, APPLE_ID, APPLE_PASSWORD: macOS code signing credentials
+
 // Based on https://github.com/electron/forge/blob/6b2d547a7216c30fde1e1fddd1118eee5d872945/packages/plugin/vite/src/VitePlugin.ts#L124
 const ignore = (file: string) => {
   if (!file) return false;
@@ -97,35 +103,38 @@ const config: ForgeConfig = {
       }),
     }),
     new MakerZIP({}),
-    // DEB maker with more robust configuration
-    new MakerDeb({
-      options: {
-        mimeType: ["x-scheme-handler/codex"],
-        maintainer: "CodeX Team <iotserver24@gmail.com>",
-        homepage: "https://github.com/iotserver24/codex",
-        categories: ["Development"],
-        // Add more specific options for better compatibility
-        depends: [
-          "libgtk-3-0",
-          "libnotify4",
-          "libnss3",
-          "libxss1",
-          "libxtst6",
-          "xdg-utils",
-          "libatspi2.0-0",
-          "libdrm2",
-          "libxkbcommon0",
-          "libxcomposite1",
-          "libxdamage1",
-          "libxfixes3",
-          "libxrandr2",
-          "libgbm1",
-          "libasound2",
-        ],
-        section: "devel",
-        priority: "optional",
-      },
-    }),
+    // DEB maker with more robust configuration - only enable if not in CI or explicitly enabled
+    // Set BUILD_DEB=false in CI to avoid compatibility issues with deb maker
+    ...(process.env.BUILD_DEB !== "false" ? [
+      new MakerDeb({
+        options: {
+          mimeType: ["x-scheme-handler/codex"],
+          maintainer: "CodeX Team <iotserver24@gmail.com>",
+          homepage: "https://github.com/iotserver24/codex",
+          categories: ["Development"],
+          // Add more specific options for better compatibility
+          depends: [
+            "libgtk-3-0",
+            "libnotify4",
+            "libnss3",
+            "libxss1",
+            "libxtst6",
+            "xdg-utils",
+            "libatspi2.0-0",
+            "libdrm2",
+            "libxkbcommon0",
+            "libxcomposite1",
+            "libxdamage1",
+            "libxfixes3",
+            "libxrandr2",
+            "libgbm1",
+            "libasound2",
+          ],
+          section: "devel",
+          priority: "optional",
+        },
+      })
+    ] : []),
     // RPM maker only for Red Hat-based systems
     ...(process.env.BUILD_RPM === "true" ? [new MakerRpm({})] : []),
   ],

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
     "extract-codebase": "ts-node scripts/extract-codebase.ts",
+    "test:forge-config": "node scripts/test-forge-config.js",
     "prepare": "husky install",
     "pre:e2e": "cross-env E2E_TEST_BUILD=true npm run package",
     "e2e": "playwright test",

--- a/scripts/test-forge-config.js
+++ b/scripts/test-forge-config.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+
+const { execSync } = require("child_process");
+
+console.log("Testing Forge Configuration...\n");
+
+// Test 1: With BUILD_DEB=false (CI mode)
+console.log("Test 1: BUILD_DEB=false (CI mode)");
+try {
+  const result = execSync("BUILD_DEB=false node -e \"const config = require('../forge.config.ts'); console.log('Config loaded successfully'); console.log('Makers count:', config.default.makers.length);\"", {
+    encoding: 'utf8',
+    stdio: 'pipe'
+  });
+  console.log("✅ Success:", result.trim());
+} catch (error) {
+  console.log("❌ Failed:", error.message);
+}
+
+console.log("\n" + "=".repeat(50) + "\n");
+
+// Test 2: With BUILD_DEB=true (default mode)
+console.log("Test 2: BUILD_DEB=true (default mode)");
+try {
+  const result = execSync("BUILD_DEB=true node -e \"const config = require('../forge.config.ts'); console.log('Config loaded successfully'); console.log('Makers count:', config.default.makers.length);\"", {
+    encoding: 'utf8',
+    stdio: 'pipe'
+  });
+  console.log("✅ Success:", result.trim());
+} catch (error) {
+  console.log("❌ Failed:", error.message);
+}
+
+console.log("\n" + "=".repeat(50) + "\n");
+
+// Test 3: With BUILD_RPM=true
+console.log("Test 3: BUILD_RPM=true");
+try {
+  const result = execSync("BUILD_RPM=true node -e \"const config = require('../forge.config.ts'); console.log('Config loaded successfully'); console.log('Makers count:', config.default.makers.length);\"", {
+    encoding: 'utf8',
+    stdio: 'pipe'
+  });
+  console.log("✅ Success:", result.trim());
+} catch (error) {
+  console.log("❌ Failed:", error.message);
+}
+
+console.log("\nConfiguration test completed!");


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes Linux build failures by making Electron Forge makers conditional and disabling DEB in CI. CI now publishes Linux ZIPs only, unblocking releases.

- **Bug Fixes**
  - Resolved MakerDeb error by gating DEB/RPM makers via env vars.
  - Set BUILD_DEB=false in CI to skip DEB on Ubuntu runners.
  - Updated workflow to upload/release only Linux ZIPs (no .deb/.rpm).
  - Adjusted release notes to reflect ZIP-only install on Linux.

- **New Features**
  - Build flags:
    - BUILD_DEB=false to disable .deb (default enabled locally).
    - BUILD_RPM=true to enable .rpm (off by default).
  - Added scripts/test-forge-config.js and npm run test:forge-config.
  - Added BUILD_FIX.md with setup, build, and testing instructions.

<!-- End of auto-generated description by cubic. -->

